### PR TITLE
Remove ytdl requirement and rewrite/cleanup the code

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,42 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1621587461,
+        "narHash": "sha256-p3NNDm0CE98BENr5eALnADnffSLi5WZUlaAMCEtNmmM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "50af5ebc0ab5370e538e2cad2ac4144d611aecbe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "utils": "utils"
+      }
+    },
+    "utils": {
+      "locked": {
+        "lastModified": 1620759905,
+        "narHash": "sha256-WiyWawrgmyN0EdmiHyG2V+fqReiVi8bM9cRdMaKQOFg=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b543720b25df6ffdfcf9227afafc5b8c1fabfae8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,21 @@
+{
+  description = "Discord twitter video embeds bot";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs";
+    utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, utils }:
+    utils.lib.eachDefaultSystem (system:
+      let pkgs = nixpkgs.legacyPackages."${system}";
+      in {
+        devShell = pkgs.mkShell {
+          nativeBuildInputs = with pkgs; [
+            pkg-config
+            nodejs-slim-16_x
+            nodePackages.pnpm
+          ];
+        };
+      });
+}

--- a/index.js
+++ b/index.js
@@ -94,6 +94,7 @@ discord.on("ready", () => {
   }); */
 });
 
+/** @param {Error} error */
 function handleError(error) {
   if (logChannel) {
     try {

--- a/index.js
+++ b/index.js
@@ -1,33 +1,38 @@
-const Discord = require("eris");
-const fs = require("fs");
-const childProcess = require("child_process");
+import Discord from "eris";
+import fs from "fs";
+import { TwitterClient, TwitterErrorList } from "./twitter.js";
 
 const config = JSON.parse(fs.readFileSync("./config.json"));
 const discord = new Discord(config.token);
 
+const twitter = new TwitterClient(
+  `Discord twitter video embeds // adryd.co/twitter-embeds`
+);
+
 let logChannel;
 
-const twitterURLRegexGlobal = /(?<!<|\|\|)https?:\/\/((mobile|www)\.)?twitter\.com\/[a-zA-Z0-9_]+\/status\/([0-9]+)/g;
-const twitterURLRegex = /(?<!<|\|\|)https?:\/\/((mobile|www)\.)?twitter\.com\/[a-zA-Z0-9_]+\/status\/([0-9]+)/;
+const TWITTER_URL_REGEX = /(?<!<|\|\|)https?:\/\/(?:(?:mobile|www)\.)?twitter\.com\/[a-zA-Z0-9_]+\/status\/([0-9]+)/gm;
 
-async function twitterDownload(twitterURL) {
-  // Just in case there's something I overlooked in the regex that would allow code execution
-  // This is still hacky af, but I don't care, if you find an RCE with just numbers, you deserve it
-  const tweetID = twitterURLRegex.exec(twitterURL)[3];
-  const safeTwitterURL = `https://twitter.com/i/status/${tweetID}`;
-  return new Promise((resolve) => {
-    childProcess.exec(
-      `youtube-dl --get-url ${safeTwitterURL}`,
-      (err, stdout, stderr) => {
-        if (stderr && stderr.includes("WARNING: Falling back on generic information extractor.")) {
-          resolve();
+/** @param {string} id */
+async function getVideoURL(id) {
+  try {
+    const videos = await twitter.getVideos(id);
+    return videos?.[0]?.url;
+  } catch (error) {
+    if (error instanceof TwitterErrorList) {
+      error.errors.forEach((err) => {
+        // Ignore page does not exist error
+        if (err.code !== 34) {
+          handleError(err);
         }
-        resolve(stdout);
-      }
-    );
-  });
+      });
+    } else {
+      handleError(error);
+    }
+  }
 }
 
+/** @param {Discord.Message} message */
 async function handleMessage(message) {
   // If the message doesn't have content, or if we're reading our own message
   if (
@@ -38,20 +43,25 @@ async function handleMessage(message) {
   ) {
     return;
   }
-  const matches = message.content.match(twitterURLRegexGlobal);
-  // If there are no Twitter URLs, we don't need to do anything
-  if (!matches) {
-    return;
-  }
-  const videoURLs = [];
-  for (let index = 0; index < matches.length; index++) {
-    videoURLs.push(await twitterDownload(matches[index]));
-  }
-  const reply = videoURLs.join("");
+
+  // Match the URL
+  // then get the video url for each id
+  const promises = [...message.content.matchAll(TWITTER_URL_REGEX)]?.map(
+    (m) => {
+      return getVideoURL(m[1]);
+    }
+  );
+
+  // Wait for all the video url fetches to finish asynchronously
+  const urls = await Promise.all(promises);
+
+  const reply = urls.join("\n");
+
   // Make sure we're not sending an empty message if no links have videos
   if (reply.length === 0) {
     return;
   }
+
   message.channel.createMessage({
     content: reply,
     messageReference: {
@@ -65,7 +75,7 @@ discord.on("messageCreate", handleMessage);
 
 discord.on("ready", () => {
   discord.getChannel(config.logChannel);
-  discord.editStatus("online", {name: "adryd.co/twitter-embeds"});
+  discord.editStatus("online", { name: "adryd.co/twitter-embeds" });
   logChannel = discord.getChannel(config.logChannel);
   logChannel.createMessage("Ready!");
   // Test code

--- a/package.json
+++ b/package.json
@@ -1,14 +1,17 @@
 {
+  "type": "module",
   "name": "discord-twitter-video-embeds",
   "version": "1.0.0",
   "description": "Replies to messages with twitter video links with the video",
   "main": "index.js",
   "scripts": {
+    "start": "node index.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "adryd <me@adryd.com>",
   "license": "MIT",
   "dependencies": {
-    "eris": "^0.15.1"
+    "eris": "^0.15.1",
+    "node-fetch": "^2.6.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,9 +2,11 @@ lockfileVersion: 5.3
 
 specifiers:
   eris: ^0.15.1
+  node-fetch: ^2.6.1
 
 dependencies:
   eris: 0.15.1
+  node-fetch: 2.6.1
 
 packages:
 
@@ -19,6 +21,11 @@ packages:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
+    dev: false
+
+  /node-fetch/2.6.1:
+    resolution: {integrity: sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==}
+    engines: {node: 4.x || >=6.0.0}
     dev: false
 
   /opusscript/0.0.8:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "allowJs": true,
+    "checkJs": true,
+    "esModuleInterop": true,
+    "moduleResolution": "node"
+  }
+}

--- a/twitter.js
+++ b/twitter.js
@@ -1,0 +1,92 @@
+import fetch from "node-fetch";
+
+// twitter guest web token
+// https://github.com/ytdl-org/youtube-dl/blob/2021.05.16/youtube_dl/extractor/twitter.py#L84
+const TWITTER_BEARER_TOKEN =
+  "Bearer AAAAAAAAAAAAAAAAAAAAAPYXBAAAAAAACLXUNDekMxqa8h%2F40K4moUkGsoc%3DTYfbDKbT3jJPCEVnMYqilB28NHfOPqkca3qaAxGfsyKCs0wRbw";
+
+const TWITTER_API_URL = "https://api.twitter.com/1.1/guest/activate.json";
+
+export class TwitterError extends Error {
+  constructor({ message, code }) {
+    super(message);
+    this.code = code;
+  }
+}
+
+export class TwitterErrorList extends Error {
+  constructor(errors) {
+    super(errors.map((err) => err.message).join("\n\n"));
+    this.errors = errors;
+  }
+}
+
+export class TwitterClient {
+  /** @param {string} userAgent */
+  constructor(userAgent) {
+    this.userAgent = userAgent;
+  }
+
+  fetchGuestToken() {
+    return fetch(TWITTER_API_URL, {
+      method: "post",
+      headers: {
+        "user-agent": this.userAgent,
+        authorization: TWITTER_BEARER_TOKEN,
+      },
+    }).then((res) => res.json());
+  }
+
+  async getGuestToken() {
+    if (!this.guestToken) {
+      const data = await this.fetchGuestToken();
+      this.guestToken = data["guest_token"];
+    }
+    return this.guestToken;
+  }
+
+  /** @param {string} id the tweet id */
+  async getVideos(id) {
+    const apiUrl = `https://api.twitter.com/2/timeline/conversation/${id}.json?tweet_mode=extended`;
+
+    return fetch(apiUrl, {
+      headers: {
+        "user-agent": this.userAgent,
+        authorization: TWITTER_BEARER_TOKEN,
+        "x-guest-token": await this.getGuestToken(),
+      },
+    })
+      .then((res) => res.json())
+      .then((res) => {
+        if (res.errors) {
+          throw new TwitterErrorList(
+            res.errors.map((err) => new TwitterError(err))
+          );
+        }
+        return res;
+      })
+      .then((conversation) => {
+        const tweets = conversation.globalObjects.tweets;
+        return tweets[
+          // Follow retweets
+          tweets[id].retweeted_status_id_str ??
+            // Follow quotes
+            tweets[id].quoted_status_id_str ??
+            id
+        ];
+      })
+      .then((tweet) =>
+        tweet.extended_entities?.media
+          ?.filter((m) => m.type === "video")
+          .flatMap(
+            (entity) =>
+              entity.video_info.variants
+                // Make sure it's a valid video
+                .filter((v) => v.bitrate)
+                // Get the highest quality
+                .sort((a, b) => b.bitrate - a.bitrate)?.[0]
+          )
+      )
+      .then((info) => (info ? (info.length > 0 ? info : null) : null));
+  }
+}


### PR DESCRIPTION
- add flake files for nixos development 
- changed node require imports to  esm imports
  - changed the modules type to `module` to enable esm imports
- replaced ytdl with handwritten js twitter client
  - added `node-fetch` as a dependency for the twitter client
- cleaned up the code and rewrote much of it
  - added basic jsdoc type annotations for typescript type hints
    - added `tsconfig.json` to enable type hints
  - replaced both `twitterURLRegex`s with a single ``TWITTER_URL_REGEX`
  - modified the url match code to be more compact
  - modified to be fully async by using Promise.all
- fixed a bug where links were not delimited by any characters when joining
  - join now uses '\n'